### PR TITLE
Add content length cap for paste creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Pasty will be available at http://localhost:8080.
 | `PASTY_DELETION_TOKEN_MASTER` | `<empty>`     | `string` | Defines the master deletion token which is authorized to delete every paste (even if deletion tokens are disabled) |
 | `PASTY_DELETION_TOKEN_LENGTH` | `12`          | `number` | Defines the length of the deletion token of a paste                                                                |
 | `PASTY_RATE_LIMIT`            | `30-M`        | `string` | Defines the rate limit of the API (see https://github.com/ulule/limiter#usage)                                     |
+| `PASTY_LENGTH_CAP`            | `50000`       | `number` | Defines the maximum amount of characters a paste is allowed to contain (a value `<= 0` means no limit)             |
 
 ## AutoDelete
 Pasty provides an intuitive system to automatically delete pastes after a specific amount of time. You can configure it with the following variables:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+volumes:
+  postgres:
+
+services:
+  postgres:
+    image: "postgres:12-alpine"
+    ports:
+      - "5432:5432"
+    volumes:
+      - "postgres:/var/lib/postgresql/data"
+    environment:
+      POSTGRES_PASSWORD: "dev"
+      POSTGRES_USER: "dev"
+      POSTGRES_DB: "pasty"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DeletionTokenMaster string
 	DeletionTokenLength int
 	RateLimit           string
+	LengthCap           int
 	AutoDelete          *AutoDeleteConfig
 	File                *FileConfig
 	Postgres            *PostgresConfig
@@ -76,6 +77,7 @@ func Load() {
 		DeletionTokenMaster: env.MustString("DELETION_TOKEN_MASTER", ""),
 		DeletionTokenLength: env.MustInt("DELETION_TOKEN_LENGTH", 12),
 		RateLimit:           env.MustString("RATE_LIMIT", "30-M"),
+		LengthCap:           env.MustInt("LENGTH_CAP", 50_000),
 		AutoDelete: &AutoDeleteConfig{
 			Enabled:      env.MustBool("AUTODELETE", false),
 			Lifetime:     env.MustDuration("AUTODELETE_LIFETIME", 720*time.Hour),

--- a/internal/web/controllers/v1/hastebin_support.go
+++ b/internal/web/controllers/v1/hastebin_support.go
@@ -13,6 +13,14 @@ import (
 
 // HastebinSupportHandler handles the legacy hastebin requests
 func HastebinSupportHandler(ctx *fasthttp.RequestCtx) {
+	// Check content length before reading body into memory
+	if config.Current.LengthCap > 0 &&
+		ctx.Request.Header.ContentLength() > config.Current.LengthCap {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString("request body length overflow")
+		return
+	}
+
 	// Define the paste content
 	var content string
 	switch string(ctx.Request.Header.ContentType()) {

--- a/internal/web/controllers/v1/pastes.go
+++ b/internal/web/controllers/v1/pastes.go
@@ -51,6 +51,14 @@ func v1GetPaste(ctx *fasthttp.RequestCtx) {
 
 // v1PostPaste handles the 'POST /v1/pastes' endpoint
 func v1PostPaste(ctx *fasthttp.RequestCtx) {
+	// Check content length before reading body into memory
+	if config.Current.LengthCap > 0 &&
+		ctx.Request.Header.ContentLength() > config.Current.LengthCap {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString("request body length overflow")
+		return
+	}
+
 	// Unmarshal the body
 	values := make(map[string]string)
 	err := json.Unmarshal(ctx.PostBody(), &values)

--- a/web/assets/js/buttons.js
+++ b/web/assets/js/buttons.js
@@ -57,7 +57,7 @@ export function setupButtons() {
             // Create the paste
             const response = await api.createPaste(input.value);
             if (!response.ok) {
-                notifications.error("Failed creating the paste: <b>" + data + "</b>");
+                notifications.error("Failed creating the paste: <b>" + await response.text() + "</b>");
                 return;
             }
             const data = await response.json();


### PR DESCRIPTION
This pull request adds a new configuration value named `LENGTH_CAP` (which defaults to `50000`). On request to the `POST /v1/pastes`, the content length header is read and compared with this config value, if it is larger than `0`. If the content length is larger than the defined cap, a `400 Bad Request` response with the content `request body length overflow` is returned.

This pull request fixes #7.