### PR TITLE
Update GitHub Action Workflow for Multi-Architecture Builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,6 @@ jobs:
           builder: ${{ steps.docker_buildx.outputs.name }}
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}, ${{ env.REGISTRY }}/${{ github.repository }}:${{ COMMIT_HASH }}
           build-args:
             PASTY_VERSION=${{ env.BRANCH }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - '**.md'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,8 +36,8 @@ jobs:
       - name: log in to ghcr
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: lus
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
           password: ${{ secrets.CR_TOKEN }}
       - name: build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,6 @@ jobs:
           builder: ${{ steps.docker_buildx.outputs.name }}
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}, ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.COMMIT_HASH }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_HASH }}
           build-args:
             PASTY_VERSION=${{ env.BRANCH }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: ${{ secrets.SERVICE_USER }} # Defined in secrets for auth to registry
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,6 @@ jobs:
           builder: ${{ steps.docker_buildx.outputs.name }}
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: ghcr.io/lus/pasty:${{ env.TAG }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}
           build-args:
             PASTY_VERSION=${{ env.BRANCH }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,6 @@ jobs:
           builder: ${{ steps.docker_buildx.outputs.name }}
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}, ${{ env.REGISTRY }}/${{ github.repository }}:${{ COMMIT_HASH }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}, ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.COMMIT_HASH }}
           build-args:
             PASTY_VERSION=${{ env.BRANCH }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,11 +34,11 @@ jobs:
         id: docker_buildx
         uses: docker/setup-buildx-action@v1
       - name: log in to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@master
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ jobs:
       - name: set up qemu
         uses: docker/setup-qemu-action@v1
       - name: set up buildx
+        id: docker_buildx
         uses: docker/setup-buildx-action@v1
       - name: log in to ghcr
         uses: docker/login-action@v1
@@ -37,6 +38,8 @@ jobs:
       - name: build and push
         uses: docker/build-push-action@v2
         with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ghcr.io/lus/pasty:${{ env.TAG }}
           build-args:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
         id: docker_buildx
         uses: docker/setup-buildx-action@v1
       - name: log in to ghcr
-        uses: docker/login-action@master
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
# Description of Changes
* update the docker workflow for GitHub actions to properly build both amd64 and arm64 images
* update the workflow to use more variables, so that actions work out of the box in forks as well

# Motivation
* eases running the workflows in forks
* enables the use of arm64 servers, devices, etc to use Pasty