### PR TITLE
Expose 8080 from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ FROM alpine:latest
 WORKDIR /root
 COPY --from=build /app/pasty .
 COPY web ./web/
+EXPOSE 8080
 CMD ["./pasty"]


### PR DESCRIPTION
Without this, users on traefik reverse proxy have to set `traefik.http.services.paste.loadbalancer.server.port="8080"`

This helps service discovery on traefik, which uses the exposed port to determine where to reverse proxy to